### PR TITLE
Remove `fish_user_key_bindings` function from `conf.d/ghq_vscode_key_bingings.fish`

### DIFF
--- a/conf.d/ghq_vscode_key_bingings.fish
+++ b/conf.d/ghq_vscode_key_bingings.fish
@@ -1,4 +1,2 @@
-function fish_user_key_bindings
-    bind \cs __ghq_vscode_open_file
-    bind \ct __ghq_vscode_open_project
-end
+bind \cs __ghq_vscode_open_file
+bind \ct __ghq_vscode_open_project


### PR DESCRIPTION
In my case, this plugin overwrites my own `fish_user_key_bindings`. According to https://github.com/fish-shell/fish-shell/blob/9292e2fd5692069d3954f454deeefa667d48b519/CHANGELOG.rst#syntax-changes-and-new-commands-2, the function is no longer necessary, so how about putting only `bind` commands on?